### PR TITLE
Patches and extensions to unittest

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,33 +1,44 @@
 ![image](https://raw.githubusercontent.com/mytechnotalent/CircuitPython_Unittest/master/CircuitPython%20Unittest.png)
 
 # CircuitPython Unittest
+
 A repo that provides the MP-Lib unittest.py to CircuitPython to allow makers to take full advantage of Python's unittest within CircuitPython.
 
 ## Installation
+
 ```bash
 git clone https://github.com/mytechnotalent/CircuitPython_Unittest.git
 ```
 
 ## Copy Files To CircuitPython Device
+
 ```bash
 unittest.py
 code.py
 test_code.py
+tests/test_code.py
 ```
 
+unittest.py could copied to the lib folder instead of the root.
+
 ## 24/7 Community Of Support
+
 If you have any questions regarding this app or implementing your own version of this app please visit us in the CircuitPython Discord channel [HERE](https://discord.com/invite/5FBsBHU) and visit the `help-with-circuitpython` room.
 
 ## Run Tests in REPL
+
 ```bash
 import unittest
 unittest.main('test_code')
+unittest.main('tests.test_code')
 ```
 
 ## Contributing
+
 Pull requests are welcome. For major changes, please open an issue first to discuss what you would like to change.
 
 Please make sure to update tests as appropriate.
 
 ## License
+
 [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0)

--- a/tests/test_code.py
+++ b/tests/test_code.py
@@ -1,0 +1,22 @@
+import unittest
+from code import foo
+
+
+class TestCode(unittest.TestCase):
+    """
+    Test class to test code module
+    """
+    
+    def test_foo(self):
+        """
+        test foo functionality
+        """
+        # Calls
+        result = foo('test')
+        
+        # Asserts
+        self.assertEqual(result, 'test!')
+
+        
+if __name__ == '__main__':
+    unittest.main()

--- a/unittest.py
+++ b/unittest.py
@@ -123,7 +123,7 @@ class TestCase:
                     result.skippedNum += 1
                     result.testsRun -= 1  # not run if skipped
                 except AssertionError as e:
-                    print(' FAIL:', e.args[0])
+                    print(' FAIL:', e.args[0] if e.args else 'no assert message')
                     result.failuresNum += 1
                 except (SystemExit, KeyboardInterrupt):
                     raise

--- a/unittest.py
+++ b/unittest.py
@@ -276,11 +276,13 @@ def skip(msg):  # noqa
     Returns:
         object
     """
-    def _decor(msg):  # noqa
+    def _decor(func):  # noqa
         """
         Inner function to handle private _decor logic
 
         Params:
+            func: function
+        Closure:
             msg: str
 
         Returns:
@@ -291,6 +293,8 @@ def skip(msg):  # noqa
             Inner function to handle replacing original fun with _inner
 
             Params:
+                self: class instance; subclass of TestCase
+            Closure:
                 msg: str
 
             Returns:
@@ -299,7 +303,6 @@ def skip(msg):  # noqa
             raise SkipTest(msg)
         return _inner
     return _decor
-
 
 def skipIf(cond, msg):  # noqa
     """
@@ -424,6 +427,7 @@ def run_class(c, test_result):
             except SkipTest as e:
                 print(' skipped:', e.args[0])
                 test_result.skippedNum += 1
+                test_result.testsRun -= 1  # not run if skipped
             except AssertionError as e:
                 print(' FAIL:', e.args[0])
                 test_result.failuresNum += 1
@@ -446,10 +450,10 @@ def main(module='__main__'):
         """
         for tn in dir(m):
             c = getattr(m, tn)  # noqa
-            if isinstance(c, object) and isinstance(c, type) and issubclass(c, TestCase):
+            if isinstance(c, type) and issubclass(c, TestCase) and c is not TestCase:
                 yield c
 
-    m = __import__(module)
+    m = __import__(module, None, None, ['*'])  # handle tests in folder
 
     suite = TestSuite()
     for c in test_cases(m):

--- a/unittest.py
+++ b/unittest.py
@@ -119,7 +119,8 @@ class TestCase:
                 except (SystemExit, KeyboardInterrupt):
                     raise
                 except Exception as e: # noqa
-                    print(' ERROR', type(e).__name__, e.args[0])
+                    print(' ERROR', type(e).__name__)
+                    print(''.join(traceback.format_exception(e)))
                     result.errorsNum += 1
                 finally:
                     self.tearDown()  # Post-test teardown (every test)

--- a/unittest.py
+++ b/unittest.py
@@ -424,10 +424,14 @@ def run_class(c, test_result):
             except SkipTest as e:
                 print(' skipped:', e.args[0])
                 test_result.skippedNum += 1
-            except:  # noqa
-                print(' FAIL')
+            except AssertionError as e:
+                print(' FAIL:', e.args[0])
                 test_result.failuresNum += 1
+            except (SystemExit, KeyboardInterrupt):
                 raise
+            except Exception as e: # noqa
+                print(' ERROR', type(e).__name__, e.args[0])
+                test_result.errorsNum += 1
             finally:
                 tear_down()
 

--- a/unittest.py
+++ b/unittest.py
@@ -1,6 +1,7 @@
 import sys
 import traceback
 
+
 class SkipTest(Exception):
     """
     Class to handle skipping test functionality
@@ -484,10 +485,9 @@ def run_class(test_class: TestCase, test_result: TestResult):
         context = 'run tests'
         testing_instance.run(test_result)
     except Exception as exc:
-        print(f'Error in {context} for {test_class.__name__}: {exc}')
-        traceback_str = traceback.format_exc()
-        print(traceback_str)
-
+        print(f'Error in {context} for {test_class.__name__}:')
+        traceback_str = traceback.format_exception(exc)
+        print(''.join(traceback_str))
         if context != 'run tests':
             context = 'early tearDownClass due to error'
 

--- a/unittest.py
+++ b/unittest.py
@@ -35,36 +35,45 @@ class AssertRaisesContext:
     Class to handle an assertion raising context
     """
 
-    def __init__(self, exc):
+    def __init__(self, exc: Exception):
         """
         Params:
-            exc: str
+            exc: Exception
         """
         self.expected = exc
+        self.raised = None
+        self.traceback = None
+        self.exception_value = None
 
     def __enter__(self):
         """
         Magic method to handle enter implementation objects used with the with statement
 
         Returns:
-            str
+            object: AssertRaisesContext
         """
         return self
 
-    def __exit__(self, exc_type):
+    def __exit__(self, exc_type: type, exc_value: Exception, traceback):
         """
         Magic method to handle exit implementation objects used with the with statement
 
         Params:
-            exc_type: str
+            exc_type: type the raised exception type (class)
+            exc_value: Exception the raised exception instance
+            traceback: the traceback for the raised exception
 
         Returns:
             bool
         """
+        self.traceback = traceback
+        self.raised = exc_type
+        self.exception_value = exc_value
         if exc_type is None:
             assert False, '%r not raised' % self.expected
         if issubclass(exc_type, self.expected):
             return True
+        # unhandled exceptions will get re-raise: Returning false indicates not handled
         return False
 
 
@@ -349,7 +358,7 @@ class TestCase:
             assert False, "%r not raised" % exc
         except Exception as e:
             if isinstance(e, exc):
-                return
+                return None
             raise
 
 

--- a/unittest.py
+++ b/unittest.py
@@ -1,5 +1,5 @@
 import sys
-
+import traceback
 
 class SkipTest(Exception):
     """
@@ -485,6 +485,9 @@ def run_class(test_class: TestCase, test_result: TestResult):
         testing_instance.run(test_result)
     except Exception as exc:
         print(f'Error in {context} for {test_class.__name__}: {exc}')
+        traceback_str = traceback.format_exc()
+        print(traceback_str)
+
         if context != 'run tests':
             context = 'early tearDownClass due to error'
 
@@ -521,3 +524,5 @@ def main(module='__main__'):
 
     # Terminate with non-zero return code in case of failures
     sys.exit(result.failuresNum > 0)
+
+# cSpell:ignore noqa

--- a/unittest.py
+++ b/unittest.py
@@ -302,6 +302,19 @@ class TestCase:
             msg = 'Expected %r to be in %r' % (x, y)
         assert x in y, msg
 
+    def assertNotIn(self, x, y, msg=''):  # noqa
+        """
+        Method to handle assert not in logic
+
+        Params:
+            x: any
+            y: any
+            msg: str, optional
+        """
+        if not msg:
+            msg = 'Expected %r to not be in %r' % (x, y)
+        assert x not in y, msg
+
     def assertIsInstance(self, x, y, msg=''):  # noqa
         """
         Method to handle assert is instance logic


### PR DESCRIPTION
This is a collection of small updates I added to my own copy of unittest.py to handle missing and broken cases noticed while using it.

- handle and report exception running test method that occurs outside of assertraises
- allow running testmodules from a sub folder instead of only in the root
- add a tests folder and duplicate example unit test to demonstrate subfolder usage
- skip looking for tests earlier if TestCase shows up in a module search (versus subclass)
- properly pass skip reason message to raised exception
- add new options for running to the README
- add whitespace to the readme markdown to make the linter happy
- move TestResults class before first reference in the module
- implement bare (do nothing) hooks in the TestCase base class
- move core test method run loop from run_class to TestCase.run
- rewrite run_class: execute new hooks for setUpClass, run, tearDownClass; add exception handling
- add missing assertNotIn method to TestCase class
- provide more detail when exceptions trapped for hooks
- fix traceback reporting for TestCase hook exceptions
- report traceback on exceptions outside assertrasises when running test methods
- fix AssertRaisesContext
- handle assertion failure that does not have any message

